### PR TITLE
fix proxy validator

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -67,7 +67,7 @@ func Provider() terraform.ResourceProvider {
 					"ALL_PROXY",
 					"all_proxy",
 				}, nil),
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^socks5h?://.*:\\d+$"), "The proxy URL is not a valid socks url."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^(socks5h?://.*:\\d+)?$"), "The proxy URL is not a valid socks url."),
 			},
 
 			"tls": {


### PR DESCRIPTION
proxy parameters is marked as optional. However, the validator func made this statement useless, it requires a valid proxy url. This change allows it to be empty.